### PR TITLE
Change colour reference for bleeds

### DIFF
--- a/Modules/AuraIndicators.lua
+++ b/Modules/AuraIndicators.lua
@@ -530,7 +530,7 @@ function EnhancedRaidFrames:UpdateIndicatorColor(indicatorFrame, remainingTime)
 				indicatorFrame.Icon:SetColorTexture(self.BLUE_COLOR:GetRGB())
 				return
 			elseif thisAura.dispelName == "bleed" then
-				indicatorFrame.Icon:SetColorTexture(self.BLOOD_RED_COLOR:GetRGB())
+				indicatorFrame.Icon:SetColorTexture(self.PINK_COLOR:GetRGB())
 			end
 		end
 	end


### PR DESCRIPTION
Bleeds referenced "BLOOD_RED_COLOR" which is not defined, the colour is defined as PINK globals.lua.